### PR TITLE
Implement execution trace (de)serialization

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,7 @@ libm = "0.2.1"
 num-traits = { version = "0.2.8", default-features = false }
 downcast-rs = { version = "1.2", default-features = false }
 paste = "1"
+serde = { version = "1.0.197", features = ["derive"] }
 
 [dev-dependencies]
 rand = "0.8.2"

--- a/crates/core/src/untyped.rs
+++ b/crates/core/src/untyped.rs
@@ -18,11 +18,12 @@ use core::{
     ops::{Neg, Shl, Shr},
 };
 use paste::paste;
+use serde::{Deserialize, Serialize};
 
 /// An untyped value.
 ///
 /// Provides a dense and simple interface to all functional Wasm operations.
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 #[repr(transparent)]
 pub struct UntypedValue {
     /// This inner value is required to have enough bits to represent

--- a/crates/wasmi/Cargo.toml
+++ b/crates/wasmi/Cargo.toml
@@ -25,6 +25,8 @@ smallvec = { version = "1.10.0", features = ["union"] }
 multi-stash = { version = "0.2.0" }
 anyhow = "1.0"
 wat = "1"
+serde = { version = "1.0.197", features = ["derive"] }
+rayon = "1.9.0"
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/crates/wasmi/src/tracer/etable.rs
+++ b/crates/wasmi/src/tracer/etable.rs
@@ -214,6 +214,39 @@ pub enum UnaryOp {
     Sqrt,
 }
 
+impl UnaryOp {
+    fn encode(self) -> u8 {
+        match self {
+            UnaryOp::Ctz => 0,
+            UnaryOp::Clz => 1,
+            UnaryOp::Popcnt => 2,
+            UnaryOp::Abs => 3,
+            UnaryOp::Neg => 4,
+            UnaryOp::Ceil => 5,
+            UnaryOp::Floor => 6,
+            UnaryOp::Trunc => 7,
+            UnaryOp::Nearest => 8,
+            UnaryOp::Sqrt => 9,
+        }
+    }
+
+    fn decode(byte: u8) -> Self {
+        match byte {
+            0 => UnaryOp::Ctz,
+            1 => UnaryOp::Clz,
+            2 => UnaryOp::Popcnt,
+            3 => UnaryOp::Abs,
+            4 => UnaryOp::Neg,
+            5 => UnaryOp::Ceil,
+            6 => UnaryOp::Floor,
+            7 => UnaryOp::Trunc,
+            8 => UnaryOp::Nearest,
+            9 => UnaryOp::Sqrt,
+            _ => panic!("invalid type"),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum BinOp {
     Add,
@@ -229,6 +262,41 @@ pub enum BinOp {
     SignedRem,
 }
 
+impl BinOp {
+    fn encode(self) -> u8 {
+        match self {
+            BinOp::Add => 0,
+            BinOp::Sub => 1,
+            BinOp::Mul => 2,
+            BinOp::Div => 3,
+            BinOp::Min => 4,
+            BinOp::Max => 5,
+            BinOp::Copysign => 6,
+            BinOp::UnsignedDiv => 7,
+            BinOp::UnsignedRem => 8,
+            BinOp::SignedDiv => 9,
+            BinOp::SignedRem => 10,
+        }
+    }
+
+    fn decode(byte: u8) -> Self {
+        match byte {
+            0 => BinOp::Add,
+            1 => BinOp::Sub,
+            2 => BinOp::Mul,
+            3 => BinOp::Div,
+            4 => BinOp::Min,
+            5 => BinOp::Max,
+            6 => BinOp::Copysign,
+            7 => BinOp::UnsignedDiv,
+            8 => BinOp::UnsignedRem,
+            9 => BinOp::SignedDiv,
+            10 => BinOp::SignedRem,
+            _ => panic!("invalid type"),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum ShiftOp {
     Shl,
@@ -238,11 +306,53 @@ pub enum ShiftOp {
     Rotr,
 }
 
+impl ShiftOp {
+    fn encode(self) -> u8 {
+        match self {
+            ShiftOp::Shl => 0,
+            ShiftOp::UnsignedShr => 1,
+            ShiftOp::SignedShr => 2,
+            ShiftOp::Rotl => 3,
+            ShiftOp::Rotr => 4,
+        }
+    }
+
+    fn decode(byte: u8) -> Self {
+        match byte {
+            0 => ShiftOp::Shl,
+            1 => ShiftOp::UnsignedShr,
+            2 => ShiftOp::SignedShr,
+            3 => ShiftOp::Rotl,
+            4 => ShiftOp::Rotr,
+            _ => panic!("invalid type"),
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum BitOp {
     And = 0,
     Or = 1,
     Xor = 2,
+}
+
+impl BitOp {
+    fn encode(self) -> u8 {
+        match self {
+            BitOp::And => 0,
+            BitOp::Or => 1,
+            BitOp::Xor => 2,
+        }
+    }
+
+    fn decode(byte: u8) -> Self {
+        match byte {
+            0 => BitOp::And,
+            1 => BitOp::Or,
+            2 => BitOp::Xor,
+            _ => panic!("invalid type"),
+        }
+    }
 }
 
 impl BitOp {
@@ -271,6 +381,47 @@ pub enum RelOp {
     UnsignedLt,
     SignedLe,
     UnsignedLe,
+}
+
+impl RelOp {
+    fn encode(self) -> u8 {
+        match self {
+            RelOp::Eq => 0u8,
+            RelOp::Ne => 1u8,
+            RelOp::Lt => 2u8,
+            RelOp::Gt => 3u8,
+            RelOp::Le => 4u8,
+            RelOp::Ge => 5u8,
+            RelOp::SignedGt => 6u8,
+            RelOp::UnsignedGt => 7u8,
+            RelOp::SignedGe => 8u8,
+            RelOp::UnsignedGe => 9u8,
+            RelOp::SignedLt => 10u8,
+            RelOp::UnsignedLt => 11u8,
+            RelOp::SignedLe => 12u8,
+            RelOp::UnsignedLe => 13u8,
+        }
+    }
+
+    fn decode(byte: u8) -> Self {
+        match byte {
+            0 => RelOp::Eq,
+            1 => RelOp::Ne,
+            2 => RelOp::Lt,
+            3 => RelOp::Gt,
+            4 => RelOp::Le,
+            5 => RelOp::Ge,
+            6 => RelOp::SignedGt,
+            7 => RelOp::UnsignedGt,
+            8 => RelOp::SignedGe,
+            9 => RelOp::UnsignedGe,
+            10 => RelOp::SignedLt,
+            11 => RelOp::UnsignedLt,
+            12 => RelOp::SignedLe,
+            13 => RelOp::UnsignedLe,
+            _ => panic!("invalid type"),
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
@@ -310,6 +461,64 @@ pub enum ConversionOp {
     F64ReinterpretI64,
     F32DemoteF64,
     F64PromoteF32,
+}
+
+trait ToBytes {
+    fn to_bytes(self) -> Vec<u8>;
+}
+
+impl ToBytes for i32 {
+    fn to_bytes(self) -> Vec<u8> {
+        self.to_be_bytes().try_into().unwrap()
+    }
+}
+
+impl ToBytes for usize {
+    fn to_bytes(self) -> Vec<u8> {
+        self.to_be_bytes().try_into().unwrap()
+    }
+}
+
+impl ToBytes for u32 {
+    fn to_bytes(self) -> Vec<u8> {
+        self.to_be_bytes().try_into().unwrap()
+    }
+}
+
+impl ToBytes for u64 {
+    fn to_bytes(self) -> Vec<u8> {
+        self.to_be_bytes().try_into().unwrap()
+    }
+}
+
+impl ToBytes for i64 {
+    fn to_bytes(self) -> Vec<u8> {
+        self.to_be_bytes().try_into().unwrap()
+    }
+}
+
+impl ToBytes for f64 {
+    fn to_bytes(self) -> Vec<u8> {
+        self.to_be_bytes().try_into().unwrap()
+    }
+}
+
+impl ToBytes for f32 {
+    fn to_bytes(self) -> Vec<u8> {
+        self.to_be_bytes().try_into().unwrap()
+    }
+}
+
+impl<T: ToBytes> ToBytes for Vec<T> {
+    fn to_bytes(self) -> Vec<u8> {
+        let mut len: Vec<u8> = (self.len() as u32).to_be_bytes().try_into().unwrap();
+
+        for elem in self {
+            len.extend(elem.to_bytes());
+        }
+
+        len
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -620,6 +829,1024 @@ pub enum StepInfo {
     },
 }
 
+impl StepInfo {
+    fn encode(self) -> Vec<u8> {
+        match self {
+            StepInfo::Br { offset } => {
+                let mut bytes = vec![0u8; 1];
+                bytes.extend(offset.to_bytes());
+
+                bytes
+            }
+            StepInfo::BrIfEqz { condition, offset } => {
+                let mut bytes = vec![1u8; 1];
+                bytes.extend(condition.to_bytes());
+                bytes.extend(offset.to_bytes());
+
+                bytes
+            }
+            StepInfo::BrIfNez { condition, offset } => {
+                let mut bytes = vec![2u8; 1];
+                bytes.extend(condition.to_bytes());
+                bytes.extend(offset.to_bytes());
+
+                assert_eq!(bytes.len(), 9);
+
+                bytes
+            }
+            StepInfo::BrAdjust { offset } => {
+                let mut bytes = vec![3u8; 1];
+                bytes.extend(offset.to_bytes());
+
+                bytes
+            }
+            StepInfo::BrTable { index, offset } => {
+                let mut bytes = vec![4u8; 1];
+                bytes.extend(index.to_bytes());
+                bytes.extend(offset.to_bytes());
+
+                bytes
+            }
+            StepInfo::Return { drop, keep_values } => {
+                let mut bytes = vec![5u8; 1];
+                bytes.extend(drop.to_bytes());
+                bytes.extend(keep_values.to_bytes());
+
+                bytes
+            }
+            StepInfo::Drop => {
+                vec![6u8; 1]
+            }
+            StepInfo::Select {
+                val1,
+                val2,
+                cond,
+                result,
+            } => {
+                let mut bytes = vec![7u8; 1];
+                bytes.extend(val1.to_bytes());
+                bytes.extend(val2.to_bytes());
+                bytes.extend(cond.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::CallInternal { args } => {
+                let mut bytes = vec![8u8; 1];
+                bytes.extend((args.len() as u32).to_bytes());
+
+                args.into_iter().fold(bytes, |mut acc, arg| {
+                    let value: Vec<u8> = arg.to_bits().to_be_bytes().try_into().unwrap();
+                    acc.extend(value);
+                    acc
+                })
+            }
+            StepInfo::CallIndirect { func_index } => {
+                let mut bytes = vec![9u8; 1];
+                bytes.extend(func_index.to_bytes());
+
+                bytes
+            }
+            StepInfo::LocalGet { depth, value } => {
+                let mut bytes = vec![10u8; 1];
+                bytes.extend(depth.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::SetLocal { depth, value } => {
+                let mut bytes = vec![11u8; 1];
+                bytes.extend(depth.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::TeeLocal { depth, value } => {
+                let mut bytes = vec![12u8; 1];
+                bytes.extend(depth.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::GetGlobal { idx, value } => {
+                let mut bytes = vec![13u8; 1];
+                bytes.extend(idx.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::SetGlobal { idx, value } => {
+                let mut bytes = vec![14u8; 1];
+                bytes.extend(idx.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::Load {
+                vtype,
+                load_size,
+                offset,
+                raw_address,
+                effective_address,
+                value,
+                block_value1,
+                block_value2,
+            } => {
+                let mut bytes = vec![15u8, vtype as u8, load_size.encode()];
+
+                bytes.extend(offset.to_bytes());
+                bytes.extend(raw_address.to_bytes());
+                bytes.extend(effective_address.to_bytes());
+                bytes.extend(value.to_bytes());
+                bytes.extend(block_value1.to_bytes());
+                bytes.extend(block_value2.to_bytes());
+
+                bytes
+            }
+            StepInfo::Store {
+                vtype,
+                store_size,
+                offset,
+                raw_address,
+                effective_address,
+                pre_block_value1,
+                updated_block_value1,
+                pre_block_value2,
+                updated_block_value2,
+                value,
+            } => {
+                let mut bytes = vec![16u8, vtype as u8, store_size.encode()];
+
+                bytes.extend(offset.to_bytes());
+                bytes.extend(raw_address.to_bytes());
+                bytes.extend(effective_address.to_bytes());
+                bytes.extend(pre_block_value1.to_bytes());
+                bytes.extend(updated_block_value1.to_bytes());
+                bytes.extend(pre_block_value2.to_bytes());
+                bytes.extend(updated_block_value2.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::MemorySize => vec![17u8; 1],
+            StepInfo::MemoryGrow { grow_size, result } => {
+                let mut bytes = vec![18u8; 1];
+                bytes.extend(grow_size.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::I32Const { value } => {
+                let mut bytes = vec![19u8; 1];
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::Const32 { value } => {
+                let mut bytes = vec![20u8; 1];
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::ConstRef { value } => {
+                let mut bytes = vec![21u8; 1];
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::I64Const { value } => {
+                let mut bytes = vec![22u8; 1];
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::I32BinOp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![23u8, class.encode()];
+
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::I32BinShiftOp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![24u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::I32BinBitOp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![25u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::I64BinOp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![26u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::I64BinShiftOp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![27u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::I64BinBitOp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![28u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::UnaryOp {
+                class,
+                vtype,
+                operand,
+                result,
+            } => {
+                let mut bytes = vec![29u8, class.encode(), vtype as u8];
+                bytes.extend(operand.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::CompZ {
+                vtype,
+                value,
+                result,
+            } => {
+                let mut bytes = vec![30u8, vtype as u8];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                match vtype {
+                    VarType::I64 => {}
+                    _ => {
+                        assert_ne!(bytes[1], 0);
+                    }
+                }
+
+                bytes
+            }
+            StepInfo::I32Comp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![31u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.push(match value {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::I64Comp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![32u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.push(match value {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::I32WrapI64 { value, result } => {
+                let mut bytes = vec![33u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::I64ExtendI32 {
+                value,
+                result,
+                sign,
+            } => {
+                let mut bytes = vec![34u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+                bytes.push(match sign {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::I32SignExtendI8 { value, result } => {
+                let mut bytes = vec![35u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::I32SignExtendI16 { value, result } => {
+                let mut bytes = vec![36u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::I64SignExtendI8 { value, result } => {
+                let mut bytes = vec![37u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::I64SignExtendI16 { value, result } => {
+                let mut bytes = vec![38u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::I64SignExtendI32 { value, result } => {
+                let mut bytes = vec![39u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::I32TruncF32 {
+                value,
+                result,
+                sign,
+            } => {
+                let mut bytes = vec![40u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+                bytes.push(match sign {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::I32TruncF64 {
+                value,
+                result,
+                sign,
+            } => {
+                let mut bytes = vec![41u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+                bytes.push(match sign {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::I64TruncF32 {
+                value,
+                result,
+                sign,
+            } => {
+                let mut bytes = vec![42u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+                bytes.push(match sign {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::I64TruncF64 {
+                value,
+                result,
+                sign,
+            } => {
+                let mut bytes = vec![43u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+                bytes.push(match sign {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::F32ConvertI32 {
+                value,
+                result,
+                sign,
+            } => {
+                let mut bytes = vec![44u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+                bytes.push(match sign {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::F32ConvertI64 {
+                value,
+                result,
+                sign,
+            } => {
+                let mut bytes = vec![45u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+                bytes.push(match sign {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::F64ConvertI32 {
+                value,
+                result,
+                sign,
+            } => {
+                let mut bytes = vec![46u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+                bytes.push(match sign {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::F64ConvertI64 {
+                value,
+                result,
+                sign,
+            } => {
+                let mut bytes = vec![47u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+                bytes.push(match sign {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::I32ReinterpretF32 { value, result } => {
+                let mut bytes = vec![48u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::I64ReinterpretF64 { value, result } => {
+                let mut bytes = vec![49u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::F32ReinterpretI32 { value, result } => {
+                let mut bytes = vec![50u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::F64ReinterpretI64 { value, result } => {
+                let mut bytes = vec![51u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::F32DemoteF64 { value, result } => {
+                let mut bytes = vec![52u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::F64PromoteF32 { value, result } => {
+                let mut bytes = vec![53u8; 1];
+                bytes.extend(value.to_bytes());
+                bytes.extend(result.to_bytes());
+
+                bytes
+            }
+            StepInfo::F32Const { value } => {
+                let mut bytes = vec![54u8; 1];
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::F64Const { value } => {
+                let mut bytes = vec![55u8; 1];
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::F32Comp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![56u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.push(match value {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::F64Comp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![57u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.push(match value {
+                    true => 1,
+                    false => 0,
+                });
+
+                bytes
+            }
+            StepInfo::F32BinOp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![58u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+            StepInfo::F64BinOp {
+                class,
+                left,
+                right,
+                value,
+            } => {
+                let mut bytes = vec![59u8, class.encode()];
+                bytes.extend(left.to_bytes());
+                bytes.extend(right.to_bytes());
+                bytes.extend(value.to_bytes());
+
+                bytes
+            }
+        }
+    }
+
+    fn decode(bytes: Vec<u8>) -> Self {
+        match bytes[0] {
+            0 => Self::Br {
+                offset: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..]).unwrap()),
+            },
+
+            1 => Self::BrIfEqz {
+                condition: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                offset: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[5..9]).unwrap()),
+            },
+            2 => {
+                let condition =
+                    i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap());
+                let offset =
+                    i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[5..9]).unwrap());
+                Self::BrIfNez { condition, offset }
+            }
+            3 => {
+                let offset =
+                    i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap());
+                Self::BrAdjust { offset }
+            }
+            4 => {
+                let index = i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap());
+                let offset =
+                    usize::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[5..9]).unwrap());
+                Self::BrTable { index, offset }
+            }
+            5 => {
+                let drop = u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap());
+                let num_values =
+                    u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[5..9]).unwrap());
+                let mut values = Vec::new();
+
+                for i in 0..num_values {
+                    let value = u64::from_be_bytes(
+                        TryInto::<[u8; 8]>::try_into(
+                            &bytes[9 + i as usize * 8..9 + i as usize * 8 + 8],
+                        )
+                        .unwrap(),
+                    );
+                    values.push(value);
+                }
+
+                Self::Return {
+                    drop,
+                    keep_values: values,
+                }
+            }
+            6 => Self::Drop,
+            7 => Self::Select {
+                val1: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                val2: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+                cond: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[17..25]).unwrap()),
+                result: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[25..33]).unwrap()),
+            },
+            8 => {
+                let num_args =
+                    u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap());
+                let mut args = Vec::new();
+
+                for i in 0..num_args {
+                    let arg = u64::from_be_bytes(
+                        TryInto::<[u8; 8]>::try_into(
+                            &bytes[5 + i as usize * 8..5 + i as usize * 8 + 8],
+                        )
+                        .unwrap(),
+                    );
+                    args.push(UntypedValue::from(arg));
+                }
+
+                Self::CallInternal { args }
+            }
+            9 => Self::CallIndirect {
+                func_index: u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..9]).unwrap()),
+            },
+            10 => Self::LocalGet {
+                depth: usize::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                value: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+            },
+            11 => Self::SetLocal {
+                depth: usize::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                value: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+            },
+            12 => Self::TeeLocal {
+                depth: usize::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                value: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+            },
+            13 => Self::GetGlobal {
+                idx: u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                value: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[5..13]).unwrap()),
+            },
+            14 => Self::SetGlobal {
+                idx: u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                value: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[5..13]).unwrap()),
+            },
+            15 => Self::Load {
+                vtype: VarType::decode(bytes[1]),
+                load_size: MemoryReadSize::decode(bytes[2]),
+                offset: u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[3..7]).unwrap()),
+                raw_address: u32::from_be_bytes(
+                    TryInto::<[u8; 4]>::try_into(&bytes[7..11]).unwrap(),
+                ),
+                effective_address: usize::from_be_bytes(
+                    TryInto::<[u8; 8]>::try_into(&bytes[11..19]).unwrap(),
+                ),
+                value: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[19..27]).unwrap()),
+                block_value1: u64::from_be_bytes(
+                    TryInto::<[u8; 8]>::try_into(&bytes[27..35]).unwrap(),
+                ),
+                block_value2: u64::from_be_bytes(
+                    TryInto::<[u8; 8]>::try_into(&bytes[35..43]).unwrap(),
+                ),
+            },
+            16 => Self::Store {
+                vtype: VarType::decode(bytes[1]),
+                store_size: MemoryStoreSize::decode(bytes[2]),
+                offset: u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[3..7]).unwrap()),
+                raw_address: u32::from_be_bytes(
+                    TryInto::<[u8; 4]>::try_into(&bytes[7..11]).unwrap(),
+                ),
+                effective_address: usize::from_be_bytes(
+                    TryInto::<[u8; 8]>::try_into(&bytes[11..19]).unwrap(),
+                ),
+                pre_block_value1: u64::from_be_bytes(
+                    TryInto::<[u8; 8]>::try_into(&bytes[19..27]).unwrap(),
+                ),
+                updated_block_value1: u64::from_be_bytes(
+                    TryInto::<[u8; 8]>::try_into(&bytes[27..35]).unwrap(),
+                ),
+                pre_block_value2: u64::from_be_bytes(
+                    TryInto::<[u8; 8]>::try_into(&bytes[35..43]).unwrap(),
+                ),
+                updated_block_value2: u64::from_be_bytes(
+                    TryInto::<[u8; 8]>::try_into(&bytes[43..51]).unwrap(),
+                ),
+                value: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[51..59]).unwrap()),
+            },
+            17 => Self::MemorySize,
+            18 => Self::MemoryGrow {
+                grow_size: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[5..9]).unwrap()),
+            },
+            19 => Self::I32Const {
+                value: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+            },
+            20 => Self::Const32 {
+                value: u32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+            },
+            21 => Self::ConstRef {
+                value: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+            },
+            22 => Self::I64Const {
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+            },
+            23 => Self::I32BinOp {
+                class: BinOp::decode(bytes[1]),
+                left: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[2..6]).unwrap()),
+                right: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[6..10]).unwrap()),
+                value: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[10..14]).unwrap()),
+            },
+            24 => Self::I32BinShiftOp {
+                class: ShiftOp::decode(bytes[1]),
+                left: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[2..6]).unwrap()),
+                right: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[6..10]).unwrap()),
+                value: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[10..14]).unwrap()),
+            },
+            25 => Self::I32BinBitOp {
+                class: BitOp::decode(bytes[1]),
+                left: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[2..6]).unwrap()),
+                right: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[6..10]).unwrap()),
+                value: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[10..14]).unwrap()),
+            },
+            26 => Self::I64BinOp {
+                class: BinOp::decode(bytes[1]),
+                left: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[2..10]).unwrap()),
+                right: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[10..18]).unwrap()),
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[18..26]).unwrap()),
+            },
+            27 => Self::I64BinShiftOp {
+                class: ShiftOp::decode(bytes[1]),
+                left: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[2..10]).unwrap()),
+                right: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[10..18]).unwrap()),
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[18..26]).unwrap()),
+            },
+            28 => Self::I64BinBitOp {
+                class: BitOp::decode(bytes[1]),
+                left: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[2..10]).unwrap()),
+                right: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[10..18]).unwrap()),
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[18..26]).unwrap()),
+            },
+            29 => Self::UnaryOp {
+                class: UnaryOp::decode(bytes[1]),
+                vtype: VarType::decode(bytes[2]),
+                operand: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[3..11]).unwrap()),
+                result: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[11..19]).unwrap()),
+            },
+            30 => Self::CompZ {
+                vtype: VarType::decode(bytes[1]),
+                value: u64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[2..10]).unwrap()),
+                result: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[10..14]).unwrap()),
+            },
+            31 => Self::I32Comp {
+                class: RelOp::decode(bytes[1]),
+                left: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[2..6]).unwrap()),
+                right: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[6..10]).unwrap()),
+                value: match bytes[10] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            32 => Self::I64Comp {
+                class: RelOp::decode(bytes[1]),
+                left: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[2..10]).unwrap()),
+                right: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[10..18]).unwrap()),
+                value: match bytes[17] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            33 => Self::I32WrapI64 {
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[9..13]).unwrap()),
+            },
+            34 => Self::I64ExtendI32 {
+                value: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[5..13]).unwrap()),
+                sign: match bytes[13] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            35 => Self::I32SignExtendI8 {
+                value: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[5..9]).unwrap()),
+            },
+            36 => Self::I32SignExtendI16 {
+                value: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[5..9]).unwrap()),
+            },
+            37 => Self::I64SignExtendI8 {
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+            },
+            38 => Self::I64SignExtendI16 {
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+            },
+            39 => Self::I64SignExtendI32 {
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+            },
+            40 => Self::I32TruncF32 {
+                value: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[5..9]).unwrap()),
+                sign: match bytes[9] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            41 => Self::I32TruncF64 {
+                value: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[9..13]).unwrap()),
+                sign: match bytes[9] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            42 => Self::I64TruncF32 {
+                value: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[5..13]).unwrap()),
+                sign: match bytes[13] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            43 => Self::I64TruncF64 {
+                value: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+                sign: match bytes[17] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            44 => Self::F32ConvertI32 {
+                value: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[5..9]).unwrap()),
+                sign: match bytes[9] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            45 => Self::F32ConvertI64 {
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[9..13]).unwrap()),
+                sign: match bytes[13] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            46 => Self::F64ConvertI32 {
+                value: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[5..13]).unwrap()),
+                sign: match bytes[13] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            47 => Self::F64ConvertI64 {
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+                sign: match bytes[17] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            48 => Self::I32ReinterpretF32 {
+                value: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[5..9]).unwrap()),
+            },
+            49 => Self::I64ReinterpretF64 {
+                value: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+            },
+            50 => Self::F32ReinterpretI32 {
+                value: i32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[5..9]).unwrap()),
+            },
+            51 => Self::F64ReinterpretI64 {
+                value: i64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[9..17]).unwrap()),
+            },
+            52 => Self::F32DemoteF64 {
+                value: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+                result: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[9..13]).unwrap()),
+            },
+            53 => Self::F64PromoteF32 {
+                value: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+                result: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[5..13]).unwrap()),
+            },
+            54 => Self::F32Const {
+                value: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[1..5]).unwrap()),
+            },
+            55 => Self::F64Const {
+                value: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[1..9]).unwrap()),
+            },
+            56 => Self::F32Comp {
+                class: RelOp::decode(bytes[1]),
+                left: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[2..6]).unwrap()),
+                right: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[6..10]).unwrap()),
+                value: match bytes[9] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            57 => Self::F64Comp {
+                class: RelOp::decode(bytes[1]),
+                left: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[2..10]).unwrap()),
+                right: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[10..18]).unwrap()),
+                value: match bytes[17] {
+                    0 => false,
+                    1 => true,
+                    _ => panic!("invalid type"),
+                },
+            },
+            58 => Self::F32BinOp {
+                class: BinOp::decode(bytes[1]),
+                left: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[2..6]).unwrap()),
+                right: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[6..10]).unwrap()),
+                value: f32::from_be_bytes(TryInto::<[u8; 4]>::try_into(&bytes[10..14]).unwrap()),
+            },
+            59 => Self::F64BinOp {
+                class: BinOp::decode(bytes[1]),
+                left: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[2..10]).unwrap()),
+                right: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[10..18]).unwrap()),
+                value: f64::from_be_bytes(TryInto::<[u8; 8]>::try_into(&bytes[18..26]).unwrap()),
+            },
+            _ => panic!("invalid type"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 pub struct ETEntry {
     pub eid: u32,
@@ -642,7 +1869,7 @@ pub struct Shard {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub enum St {
     M(usize),
-    I(StepInfo),
+    I(Vec<u8>),
     D(isize),
 }
 
@@ -696,7 +1923,7 @@ impl ETable {
                             v.push(St::D(sp_delta));
                         }
 
-                        v.push(St::I(step.step_info.clone()));
+                        v.push(St::I(step.step_info.clone().encode()));
                         v
                     })
                     .flatten()
@@ -730,7 +1957,7 @@ impl ETable {
                         },
                         allocated_memory_pages,
                         sp: stack_pointer,
-                        step_info,
+                        step_info: StepInfo::decode(step_info),
                     }),
                     St::M(mem) => {
                         allocated_memory_pages = mem;

--- a/crates/wasmi/src/tracer/imtable.rs
+++ b/crates/wasmi/src/tracer/imtable.rs
@@ -1,8 +1,9 @@
+use serde::{Deserialize, Serialize};
 use wasmi_core::ValueType;
 
 use super::mtable::LocationType;
 
-#[derive(Clone, Copy, Debug, PartialEq, Hash, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Hash, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum MemoryReadSize {
     U8 = 1,
     S8,
@@ -31,7 +32,7 @@ impl MemoryReadSize {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Hash, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Hash, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum MemoryStoreSize {
     Byte8 = 1,
     Byte16,
@@ -50,7 +51,7 @@ impl MemoryStoreSize {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum VarType {
     I64 = 0,
     I32 = 1,

--- a/crates/wasmi/src/tracer/imtable.rs
+++ b/crates/wasmi/src/tracer/imtable.rs
@@ -30,6 +30,35 @@ impl MemoryReadSize {
             MemoryReadSize::F64 => 8,
         }
     }
+
+    pub fn encode(self) -> u8 {
+        match self {
+            MemoryReadSize::U8 => 0,
+            MemoryReadSize::S8 => 1,
+            MemoryReadSize::U16 => 2,
+            MemoryReadSize::S16 => 3,
+            MemoryReadSize::U32 => 4,
+            MemoryReadSize::S32 => 5,
+            MemoryReadSize::I64 => 6,
+            MemoryReadSize::F32 => 7,
+            MemoryReadSize::F64 => 8,
+        }
+    }
+
+    pub fn decode(byte: u8) -> Self {
+        match byte {
+            0 => Self::U8,
+            1 => Self::S8,
+            2 => Self::U16,
+            3 => Self::S16,
+            4 => Self::U32,
+            5 => Self::S32,
+            6 => Self::I64,
+            7 => Self::F32,
+            8 => Self::F64,
+            _ => panic!("invalid type"),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Hash, Eq, PartialOrd, Ord, Deserialize, Serialize)]
@@ -49,6 +78,25 @@ impl MemoryStoreSize {
             MemoryStoreSize::Byte64 => 8,
         }
     }
+
+    pub fn encode(self) -> u8 {
+        match self {
+            Self::Byte8 => 0,
+            Self::Byte16 => 1,
+            Self::Byte32 => 2,
+            Self::Byte64 => 3,
+        }
+    }
+
+    pub fn decode(byte: u8) -> Self {
+        match byte {
+            0 => Self::Byte8,
+            1 => Self::Byte16,
+            2 => Self::Byte32,
+            3 => Self::Byte64,
+            _ => panic!("invalid type"),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Deserialize, Serialize)]
@@ -59,6 +107,20 @@ pub enum VarType {
     F64 = 3,
     FuncRef = 4,
     ExternRef = 5,
+}
+
+impl VarType {
+    pub fn decode(byte: u8) -> Self {
+        match byte {
+            0 => VarType::I64,
+            1 => VarType::I32,
+            2 => VarType::F32,
+            3 => VarType::F64,
+            4 => VarType::FuncRef,
+            5 => VarType::ExternRef,
+            _ => panic!("invalid type"),
+        }
+    }
 }
 
 impl From<ValueType> for VarType {

--- a/crates/wasmi/src/tracer/mtable.rs
+++ b/crates/wasmi/src/tracer/mtable.rs
@@ -113,7 +113,7 @@ pub fn memory_event_of_step(event: &ETEntry, emid: &mut u32) -> Vec<MemoryTableE
         StepInfo::Br { .. } => vec![],
         StepInfo::BrIfEqz { .. } => vec![],
         StepInfo::BrIfNez { .. } => vec![],
-        StepInfo::BrTable {..} => vec![],
+        StepInfo::BrTable { .. } => vec![],
         StepInfo::BrAdjust { .. } => vec![],
         StepInfo::Return { drop, keep_values } => {
             let mut ops = vec![];


### PR DESCRIPTION
This PR is split into two commits:
  * add support for serde's (de)serialization
  * compact instruction table into byte array

The first commit introduces `Shard` which is a more compact representation of `ETEntry`, only storing a delta of stack pointer/memory pages for more efficient transportation of `ETable`s. Each `Shard` contains the start stack pointer so an identical `ETable` can be constructed from `Shard` by traversing through stack pointer/memory page deltas. As discussed, this shaved some ~44% of each shard.

The second commit, which I'm not sure we should merge, compacts instructions into byte arrays, for even more efficient over-the-wire representation. Problem is, however, that the maintenance burden is quite high for this optimization and it removed only ~4-5MB of the final shard, which I'm not sure is worth the cost. We can drop the commit from this PR and revisit it later if we deem it's a worthwhile optimization.

cc @Forpee @wyattbenno777 